### PR TITLE
Typing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,20 @@
 dev:
 	pip install -e .
 
-.PHONY: test
-test:
+.PHONY: typehint
+typehint: testdeps
+	mypy compressor/
+
+.PHONY: testdeps
+testdeps:
 	pip install -e .[tests]
+
+.PHONY: test
+test: testdeps
 	pytest
+
+.PHONY: checklist
+checklist: typehint test
 
 .PHONY: clean
 clean:

--- a/compressor/core.py
+++ b/compressor/core.py
@@ -230,7 +230,7 @@ def save_compressed_file(filename: str, table: dict, checksum: int,
     Given the original file by its `filename`, save a new one.
     `table` contains the new codes for each character on `filename`.
     """
-    new_file = dest_file or _brand_filename(filename)
+    new_file = dest_file or brand_filename(filename)
 
     with open(new_file, 'wb') as target:
         _save_checksum(target, checksum)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 from compressor.constants import VERSION
 
-tests_require = ['pytest', 'pytest-cov', 'codecov']
+tests_require = ['pytest', 'pytest-cov', 'codecov', 'mypy']
 docs_require = ['Sphinx', 'sphinx-autodoc-annotation']
 
 


### PR DESCRIPTION
# Requisites

- ✅ Tests Pass
 
- [ ] Lint/PEP8 pass (unavailable yet)

- ✅  Documentation updated

# Summary of changes

Add ``mypy`` and set the ``Makefile``, to run the checks on the project. Will *not* be part of the CI yet, because ``mypy`` is unstable, and reports false positives. However, these placeholders work.

Fixes https://github.com/rmariano/compr/issues/21