### PR TITLE
improve-names: for functions.{pack,unpack}

### DIFF
--- a/compressor/functions.py
+++ b/compressor/functions.py
@@ -54,5 +54,11 @@ def patched_struct(struct_function: Callable) -> Callable:
     return wrapped
 
 
-pack = patched_struct(struct.pack)  # pylint: disable=invalid-name
-unpack = patched_struct(struct.unpack)  # pylint: disable=invalid-name
+@patched_struct
+def pack(code, *args):
+    return struct.pack(code, *args)
+
+
+@patched_struct
+def unpack(code, *args):
+    return struct.unpack(code, *args)

--- a/compressor/functions.py
+++ b/compressor/functions.py
@@ -56,9 +56,15 @@ def patched_struct(struct_function: Callable) -> Callable:
 
 @patched_struct
 def pack(code, *args):
+    """Original struct.pack with the decorator applied.
+    Will change the code according to the system's architecture.
+    """
     return struct.pack(code, *args)
 
 
 @patched_struct
 def unpack(code, *args):
+    """Original struct.unpack with the decorator applied.
+    Will change the code according to the system's architecture.
+    """
     return struct.unpack(code, *args)

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -9,9 +9,19 @@ def test_endianess_prefix_bigendinan(monkeypatch):
     assert endianess_prefix() == '>'
 
 
+def test_endianess_prefix_littleendian(monkeypatch):
+    monkeypatch.setattr(sys, 'byteorder', 'little')
+    assert endianess_prefix() == '<'
+
+
 def test_endianess_prefix_bytes(monkeypatch):
     monkeypatch.setattr(sys, 'byteorder', 'big')
     assert endianess_prefix(bytes) == b'>'
+
+
+def test_littleendian_bytes(monkeypatch):
+    monkeypatch.setattr(sys, 'byteorder', 'little')
+    assert endianess_prefix(bytes) == b'<'
 
 
 def test_packing(monkeypatch):


### PR DESCRIPTION
# Requisites

- ✅  Documentation updated: n/a

# Summary of changes
Use the decorator with the notation.

Remove a pylint warning that was ignored.